### PR TITLE
wording fix in Modularization section

### DIFF
--- a/docs/snakefiles/modularization.rst
+++ b/docs/snakefiles/modularization.rst
@@ -132,14 +132,14 @@ With Snakemake 6.0 and later, it is possible to define external workflows as mod
     
     use rule * from other_workflow as other_*
 
-The first statement registers the external workflow as a module, by defining the path to the main snakefile.
+The ``module other_workflow:`` statement registers the external workflow as a module, by defining the path to the main snakefile of ``other_workflow``.
 Here, plain paths, HTTP/HTTPS URLs and special markers for code hosting providers like Github or Gitlab are possible (see :ref:`snakefile-code-hosting-providers`).
-The second statement declares all rules of that module to be used in the current one.
-Thereby, the ``as other_*`` at the end renames all those rule with a common prefix.
+The second statement, ``use rule * from other_workflow as other_*``, declares all rules of that module to be used in the current one.
+Thereby, the ``as other_*`` at the end renames all those rules with a common prefix.
 This can be handy to avoid rule name conflicts (note that rules from modules can otherwise overwrite rules from your current workflow or other modules).
 The module is evaluated in a separate namespace, and only the selected rules are added to the current workflow.
 Non-rule Python statements inside the module are also evaluated in that separate namespace.
-They are available in the module-defining workflow under the name of the module (e.g. here ``other_workflow.myfunction()`` would call the function ``myfunction`` that has been define in the model, e.g. in ``other_workflow/Snakefile``).
+They are available in the module-defining workflow under the name of the module (e.g. here ``other_workflow.myfunction()`` would call the function ``myfunction`` that has been defined in the model, e.g. in ``other_workflow/Snakefile``).
 
 It is possible to overwrite the global config dictionary for the module, which is usually filled by the ``configfile`` statement (see :ref:`snakefiles_standard_configuration`):
 


### PR DESCRIPTION


### Description

- orthography fixed
- removed implicit pointers to code `first statement`, `second statement` which could be misleading

### QC
<!-- Make sure that you can tick the boxes below. -->

* ~~[ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.~~
* ~~[ ] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).~~
